### PR TITLE
bump version to 1.0.0-beta.9

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0-beta.7
+current_version = 1.0.0-beta.8
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0-beta.8
+current_version = 1.0.0-beta.9
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# changlog
+
+## 1.0.0-beta.9
+
+* Add `_from_trust` option for address iniitialization. If set, the address initialization will not validate address input and will directly use the input as an encoded base32 address
+* Add `public_key_to_cfx_hex` util. Add `Base32Address.from_public_key` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 * Add `_from_trust` option for address initialization. If set, the address initialization will not validate address input and will directly use the input as an encoded base32 address
 * Add `public_key_to_cfx_hex` util. Add `Base32Address.from_public_key`
+* internal util `hex_address_bytes` is removed, and is replaced by using `hexbytes.HexBytes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 1.0.0-beta.9
 
-* Add `_from_trust` option for address iniitialization. If set, the address initialization will not validate address input and will directly use the input as an encoded base32 address
-* Add `public_key_to_cfx_hex` util. Add `Base32Address.from_public_key` 
+* Add `_from_trust` option for address initialization. If set, the address initialization will not validate address input and will directly use the input as an encoded base32 address
+* Add `public_key_to_cfx_hex` util. Add `Base32Address.from_public_key`

--- a/cfx_address/__init__.py
+++ b/cfx_address/__init__.py
@@ -5,11 +5,13 @@ from cfx_address.utils import (
     validate_base32
 )
 from cfx_address.utils import (
-    eth_eoa_address_to_cfx_hex
+    eth_eoa_address_to_cfx_hex,
+    public_key_to_cfx_hex,
 )
 
 __all__ = [
     "Base32Address",
     "validate_base32",
-    "eth_eoa_address_to_cfx_hex"
+    "eth_eoa_address_to_cfx_hex",
+    "public_key_to_cfx_hex",
 ]

--- a/cfx_address/__init__.py
+++ b/cfx_address/__init__.py
@@ -2,10 +2,14 @@ from cfx_address.address import (
     Base32Address
 )
 from cfx_address.utils import (
+    validate_base32
+)
+from cfx_address.utils import (
     eth_eoa_address_to_cfx_hex
 )
 
 __all__ = [
     "Base32Address",
+    "validate_base32",
     "eth_eoa_address_to_cfx_hex"
 ]

--- a/cfx_address/_utils.py
+++ b/cfx_address/_utils.py
@@ -1,10 +1,21 @@
 # utils do not rely on other modules are defined here to avoid recursive import
-from typing import Any, Literal
+from typing import (
+    Any,
+    Literal,
+    Union,
+    cast,
+)
+from hexbytes import (
+    HexBytes,
+)
 
 from cfx_utils.exceptions import (
     InvalidNetworkId,
     InvalidHexAddress, 
     
+)
+from eth_utils.crypto import (
+    keccak
 )
 from eth_utils.address import (
     is_hex_address
@@ -12,6 +23,18 @@ from eth_utils.address import (
 from eth_typing.evm import (
     HexAddress,
 )
+
+def public_key_to_cfx_hex(public_key: Union[str, bytes]) -> HexAddress:
+    """
+    return the corresponding hex address of a public key in conflux: "0x1" + keccak(pk).hex()[-39]
+    
+    :param Union[str, bytes] public_key: str or bytes representation of public key
+    :return HexAddress: Hex representation of the correspondign hex address
+    """    
+    public_key = HexBytes(public_key)
+    # only EOA has a corresponding public key
+    address = "0x1" + keccak(public_key).hex()[-39:]
+    return cast(HexAddress, address)
 
 def eth_eoa_address_to_cfx_hex(eoa_address: str) -> HexAddress:
     """
@@ -30,11 +53,6 @@ def eth_eoa_address_to_cfx_hex(eoa_address: str) -> HexAddress:
     """
     validate_hex_address(eoa_address)
     return '0x1' + eoa_address.lower()[3:] # type: ignore
-
-
-def hex_address_bytes(hex_address: str) -> bytes:
-    assert type(hex_address) == str
-    return bytes.fromhex(hex_address.lower().replace('0x', ""))
 
 def validate_network_id(network_id: Any) -> Literal[True]:
     """

--- a/cfx_address/_utils.py
+++ b/cfx_address/_utils.py
@@ -30,6 +30,10 @@ def public_key_to_cfx_hex(public_key: Union[str, bytes]) -> HexAddress:
     
     :param Union[str, bytes] public_key: str or bytes representation of public key
     :return HexAddress: Hex representation of the correspondign hex address
+    
+    
+    >>> public_key_to_cfx_hex("0xdacdaeba8e391e7649d3ac4b5329ca0e202d38facd928d88b5f729b89a497e43cc4ad3816fcfdb241497b3b43862afb4c899bc284bf60feca4ee66ff868d1feb")
+    '0x152d251c36aec31072b90a85b95bf9435b07edb8'
     """    
     public_key = HexBytes(public_key)
     # only EOA has a corresponding public key

--- a/cfx_address/address.py
+++ b/cfx_address/address.py
@@ -86,15 +86,15 @@ class Base32Address(str):
     ['user', 1, '0x1ecde7223747601823f7535d7968ba98b4881e09', 'CFXTEST:TYPE.USER:AATP533CG7D0AGBD87KZ48NJ1MPNKCA8BE1RZ695J4', 'cfxtest:aat...95j4', '0x349f086998cF4a0C5a00b853a0E93239D81A97f6', '0x1ECdE7223747601823f7535d7968Ba98b4881E09']
     """    
     
-    def __new__(cls, address: Union["Base32Address", HexAddress, str], network_id: Optional[int]=None, verbose: bool = False, from_trusted_source: bool = False) -> "Base32Address":
+    def __new__(cls, address: Union["Base32Address", HexAddress, str], network_id: Optional[int]=None, verbose: Optional[bool] = None, _from_trust: bool = False) -> "Base32Address":
         """
         :param Union[Base32Address, HexAddress, str] address: a base32-or-hex format address
         :param Optional[int] network_id: target address network_id. Optional if first argument is a base32 address, but required for hex address
-        :param bool verbose: whether the return value will be encoded in verbose mode, defaults to False
-        :param bool from_trusted_source: whether the value is a verified Base32Address, defaults to False
+        :param Optional[bool] verbose: whether the return value will be encoded in verbose mode, defaults to None (will be viewed as None)
+        :param bool _from_trust: whether the value is a verified Base32Address, if true, network_id and verbose option should be None, and the verification and encoding process will be skipped. Not recommended to set unless preformance is critical. Defaults to False
         :raises InvalidAddress: address is neither base32 address nor hex address
         :raises InvalidNetworkId: network_id argument is not a positive integer or is None when address argument is a hex address
-        :return Base32Address: an encoded base32 object, which can be trivially used as python str
+        :return Base32Address: an encoded base32 object, which can be trivially used as python str, specially, if from_trusted_source is true, the input value will be directly used as the encoded value
         
         :examples:
         
@@ -107,10 +107,12 @@ class Base32Address(str):
         >>> isinstance(address_, str)
         True
         """
-        if from_trusted_source:
+        if _from_trust:
             if network_id is not None or verbose is not None:
                 raise ArgumentError("wrong argument: network_id and verbose should be None if from_trusted_source is True")
             return str.__new__(cls, address)
+        if verbose is None:
+            verbose = False
         try:
             parts = cls.decode(address)
             if network_id is None:

--- a/cfx_address/address.py
+++ b/cfx_address/address.py
@@ -168,6 +168,9 @@ class Base32Address(str):
         :param int network_id: network id of the return Base32Address, defaults to None
         :param bool verbose: whether the address will be represented in verbose mode, defaults to False
         :return Base32Address: Base32 representation of the address
+        
+        >>> Base32Address.from_public_key("0xdacdaeba8e391e7649d3ac4b5329ca0e202d38facd928d88b5f729b89a497e43cc4ad3816fcfdb241497b3b43862afb4c899bc284bf60feca4ee66ff868d1feb", 1)
+        'cfxtest:aamw4kj6g41pgedw1efjnsm59fbz0b9r1awbp8k2p2'
         """
         hex_address = public_key_to_cfx_hex(public_key)
         return cls(hex_address, network_id, verbose)

--- a/cfx_address/utils.py
+++ b/cfx_address/utils.py
@@ -1,7 +1,12 @@
 from typing import (
     Optional,
     Union,
-    cast
+    cast,
+    Literal,
+)
+
+from eth_utils.address import (
+    is_hex_address,
 )
 
 from cfx_address._utils import (
@@ -12,10 +17,11 @@ from cfx_address._utils import (
 from cfx_address.address import (
     Base32Address
 )
-from eth_utils.address import (
-    is_hex_address,
-)
 
+from cfx_utils.exceptions import (
+    Base32AddressNotMatch,
+    AddressNotMatch,
+)
 from cfx_utils.types import (
     HexAddress,
 )
@@ -38,16 +44,54 @@ def normalize_to(
     else:
         if is_hex_address(address):
             return cast(HexAddress, address)
+        # error will be raised if address is not a Base32Address
         return Base32Address(address).hex_address
 
-# def is_valid_address(value: str) -> bool:
-#     """
-#     checks if a value is a valid string-typed address, either hex address or base32 address is ok
+def validate_address_agaist_network_id(address: str, network_id: Union[int, None], accept_hex: Optional[bool]=False) -> Literal[True]:
+    """
+    Validate address in specific network context. Error will be raised only if:
+        1. address validity checking: 
+            address is a base32 address or hex / base32 address if accept_hex
+        2. network id validity checking: 
+            the network id of the address should be same as network_id, this step will be skipped if address is hex address or network_id is None
 
-#     :param Any value: value to check
-#     :return bool: True if valid, otherwise False
-#     """    
-#     return is_hex_address(value) or is_valid_base32(value)
+    :param str address: address to validate
+    :param Union[int, None] network_id: if is None, then network id checking will be skipped
+    :param Optional[bool] accept_hex: whether a hex address is accepted, if. Defaults to False
+    :raises AddressNotMatch: hex address is received when accept_hex is not True
+    :raises Base32AddressNotMatch: the network id of address does not equal to network_id
+    :return Literal[True]: returns True if no exceptions are raised
+    
+    >>> from cfx_address.utils import validate_address_agaist_network_id
+    >>> address = Base32Address.zero_address(1)
+    >>> validate_address_agaist_network_id(address, 1)
+    True
+    >>> validate_address_agaist_network_id(address.hex_address, 1, True)
+    True
+    >>> validate_address_agaist_network_id(address, None)
+    True
+    >>> validate_address_agaist_network_id(address.hex_address, None)
+    Traceback (most recent call last):
+        ...
+    cfx_utils.exceptions.AddressNotMatch: hex address is not accepted
+    >>> validate_address_agaist_network_id(address, 1029)
+    Traceback (most recent call last):
+        ...
+    cfx_utils.exceptions.Base32AddressNotMatch: expects address of network id 1029, receives address of network id 1
+    
+    """    
+    if is_hex_address(address):
+        if accept_hex:
+            return True
+        raise AddressNotMatch("hex address is not accepted")
+    else:
+        # the address is Base32Address (or invalid)
+        address_network_id = Base32Address.decode(address)["network_id"]
+        if address_network_id == network_id or network_id is None:
+            return True
+        raise Base32AddressNotMatch(f"expects address of network id {network_id}, "
+                                    f"receives address of network id {address_network_id}")
+
 
 __all__ = [
     "validate_hex_address",
@@ -55,5 +99,6 @@ __all__ = [
     "eth_eoa_address_to_cfx_hex",
     "validate_base32",
     "is_valid_base32",
+    "validate_address_agaist_network_id",
     # "is_hex_address"
 ]

--- a/cfx_address/utils.py
+++ b/cfx_address/utils.py
@@ -12,7 +12,8 @@ from eth_utils.address import (
 from cfx_address._utils import (
     validate_hex_address,
     validate_network_id,
-    eth_eoa_address_to_cfx_hex
+    eth_eoa_address_to_cfx_hex,
+    public_key_to_cfx_hex,
 )
 from cfx_address.address import (
     Base32Address

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ author = "Zhang Wenda"
 
 # The full version, including alpha/beta/rc tags
 # modify by bumpversion
-release = "1.0.0-beta.7"
+release = "1.0.0-beta.8"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ author = "Zhang Wenda"
 
 # The full version, including alpha/beta/rc tags
 # modify by bumpversion
-release = "1.0.0-beta.8"
+release = "1.0.0-beta.9"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with open('./README.md') as readme:
 setup(
     # the name must match the folder name 'verysimplemodule'
     name="cfx-address",
-    version="1.0.0-beta.7", # edit using bumpversion
+    version="1.0.0-beta.8", # edit using bumpversion
     author="The Conflux foundation",
     author_email="wangpan@conflux-chain.org",
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with open('./README.md') as readme:
 setup(
     # the name must match the folder name 'verysimplemodule'
     name="cfx-address",
-    version="1.0.0-beta.8", # edit using bumpversion
+    version="1.0.0-beta.9", # edit using bumpversion
     author="The Conflux foundation",
     author_email="wangpan@conflux-chain.org",
     long_description_content_type='text/markdown',

--- a/tests/address_test.py
+++ b/tests/address_test.py
@@ -41,6 +41,9 @@ mapped_evm_space_address = "0x349f086998cF4a0C5a00b853a0E93239D81A97f6"
 eoa_address = "0xd43d2a93e97245E290feE74276a1EF8D275bE646"
 # converted_address = "0x143d2a93e97245e290fee74276a1ef8d275be646"
 
+pk = "0xdacdaeba8e391e7649d3ac4b5329ca0e202d38facd928d88b5f729b89a497e43cc4ad3816fcfdb241497b3b43862afb4c899bc284bf60feca4ee66ff868d1feb"
+pk_address = "0x152d251c36aec31072b90a85b95bf9435b07edb8"
+
 def test_validation():
     assert Base32Address.is_valid_base32(testnet_address)
     assert Base32Address.is_valid_base32(mainnet_address)
@@ -131,3 +134,7 @@ def test_init_from_trusted():
     # test __eq__
     assert instance == testnet_verbose_address
     assert instance == testnet_address
+
+def test_init_from_public_key():
+    instance = Base32Address.from_public_key(pk, 1)
+    assert instance == Base32Address(pk_address, 1)

--- a/tests/address_test.py
+++ b/tests/address_test.py
@@ -111,3 +111,23 @@ def test_instance():
     # test __eq__
     assert instance == testnet_verbose_address
     assert instance == testnet_address
+
+
+def test_init_from_trusted():
+    instance = Base32Address(testnet_verbose_address, _from_trust=True)
+    assert isinstance(instance, Base32Address)
+    assert isinstance(instance.eth_checksum_address, str)
+    assert instance.network_id == 1
+    assert instance.hex_address == hex_address
+    assert instance.eth_checksum_address == checksum_address
+    assert instance.verbose_address == testnet_verbose_address
+    assert instance.address_type == "user"
+    assert instance.abbr == shortened_testnet_address
+    assert instance.mapped_evm_space_address == mapped_evm_space_address
+    
+    assert Base32Address(mainnet_verbose_address, None, True).abbr == shortened_mainnet_address
+    assert Base32Address(mainnet_verbose_address, None).compressed_abbr == compressed_shortened_mainnet_address
+    
+    # test __eq__
+    assert instance == testnet_verbose_address
+    assert instance == testnet_address

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,7 +1,16 @@
+import pytest
 from cfx_address.utils import (
     eth_eoa_address_to_cfx_hex,
-    normalize_to
+    normalize_to,
+    validate_address_agaist_network_id
     # is_valid_address,
+)
+from cfx_address import (
+    Base32Address
+)
+from cfx_utils.exceptions import (
+    AddressNotMatch,
+    Base32AddressNotMatch
 )
 
 eoa_address = "0xd43d2a93e97245E290feE74276a1EF8D275bE646"
@@ -25,3 +34,13 @@ def test_normalize():
     assert normalize_to(testnet_verbose_address, 1029) == mainnet_address
     assert normalize_to(hex_address, None) == hex_address
     assert normalize_to(hex_address, 1) == testnet_verbose_address
+    
+def test_validate_against_network_id():
+    address = Base32Address.zero_address(1)
+    assert validate_address_agaist_network_id(address, 1)
+    assert validate_address_agaist_network_id(address.hex_address, 1, True)
+    assert validate_address_agaist_network_id(address, None)
+    with pytest.raises(AddressNotMatch):
+        validate_address_agaist_network_id(address.hex_address, None)
+    with pytest.raises(Base32AddressNotMatch):
+        validate_address_agaist_network_id(address, 1029)


### PR DESCRIPTION
* Add `_from_trust` option for address iniitialization. If set, the address initialization will not validate address input and will directly use the input as an encoded base32 address
* Add `public_key_to_cfx_hex` util. Add `Base32Address.from_public_key` method

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-fans/cfx-address/3)
<!-- Reviewable:end -->
